### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:14-alpine
+
+COPY . /beautiful-tucan
+
+RUN cd beautiful-tucan \
+    && npm install \
+    && npm run init
+
+
+FROM python:3.7-slim
+
+COPY . /beautiful-tucan
+COPY --from=0 /beautiful-tucan/dist /beautiful-tucan/dist
+
+WORKDIR /beautiful-tucan
+
+RUN pip install mechanicalsoup pystache mypy
+
+CMD sh make.sh && cp -r gh-pages/* /dist

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ for example via cp or rsync:
 $ cp -v -r gh-pages/* ~/.public_html/beautiful-tucan/
 ~~~
 
+## Docker
+
+Alternatively, it is also possible to perform build and run using Docker:
+
+~~~
+docker build -t beautiful-tucan .
+docker run --rm -e TUID_USER=<TU_USER> -e TUID_PASS=<TU_PASSWORD> -v <OUTPUT_PATH>:/dist beautiful-tucan
+~~~
+
+
 # LICENCE
 
 This code is based on tucan-crawler by davidgengenbach, which is GPL licenced.


### PR DESCRIPTION
This PR allows building the webpage using just a single Docker command.

This is especially useful for installations with `python3.8` set up (like mine 😠), which is unfortunately incompatible with `beautiful-tucan`. In future, it might also be a neat addition for automated page updates via CD.