### PR TITLE
Implement printer-friendly view

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,6 +51,12 @@ summary b {padding:.5em; padding-bottom:0; display:block}
   #main2 {position: fixed; top:0; right:0; height: 100vh; overflow-y:scroll; padding:3em 1em}
 }
 
+/* print the right pane only */
+@media print {
+  #main2 {width: 100%}
+  #main3 {display: none}
+}
+
 .color-0 {background: hsl(0,100%,80%)}
 .color-1 {background: hsl(60,100%,80%)}
 .color-2 {background: hsl(120,100%,80%)}


### PR DESCRIPTION
Fairly simple css change causing the browser to only print out the right pane (a preview is available when hitting Ctrl+P and also allows a clean PDF export). The feature could be refined by adding a title and removing the iCal link. However, this would probably require some HTML changes and I didn't have a look into the templating mechanism yet. The resulting sheet looks the following:

![print_feat_preview](https://user-images.githubusercontent.com/22484496/196994694-a025d41d-d9b3-4fea-aabb-56edc1b6634a.png)

I know it's archaic, but I really like having a physical print of my schedule 😄 